### PR TITLE
Improve step parsing with quotes and comment tool

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,12 @@
         }
         @keyframes blink { 50% { opacity: 0; } }
         .katex-display { margin: 0; padding: 1rem; }
+        body.minimal-mode {
+            font-size: 0.75rem;
+        }
+        body.minimal-mode #status-panel { display: none; }
+        body.minimal-mode #main-container { grid-template-columns: 1fr !important; }
+        body.minimal-mode textarea { min-height: 60px; }
     </style>
 </head>
 
@@ -53,9 +59,16 @@
     <header class="p-4 text-center">
         <h1 class="text-3xl font-bold text-white">Agentic AI Companion</h1>
         <p class="text-md text-gray-400">A multi-modal interface for complex AI task execution.</p>
+        <div class="flex items-center justify-center mt-2 space-x-2">
+            <span class="text-sm text-gray-300">Minimal Mode</span>
+            <label class="relative inline-block w-10 align-middle select-none">
+                <input type="checkbox" id="minimal-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer" />
+                <span class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-600"></span>
+            </label>
+        </div>
     </header>
 
-    <main class="flex-grow container mx-auto p-4 grid grid-cols-1 lg:grid-cols-3 gap-6 overflow-hidden">
+    <main id="main-container" class="flex-grow container mx-auto p-4 grid grid-cols-1 lg:grid-cols-3 gap-6 overflow-hidden">
 
         <div class="lg:col-span-2 flex flex-col gap-6 overflow-hidden">
             <div class="glass-panel rounded-xl shadow-2xl p-6">
@@ -94,7 +107,7 @@
             </div>
         </div>
 
-        <div class="glass-panel rounded-xl shadow-2xl flex flex-col overflow-hidden">
+        <div id="status-panel" class="glass-panel rounded-xl shadow-2xl flex flex-col overflow-hidden">
             <div class="p-4 border-b border-gray-700/50">
                  <h2 class="text-lg font-semibold flex items-center"><i class="ph ph-list-checks mr-2"></i>Agent Status</h2>
                  <div id="status-indicator" class="mt-2 text-center p-2 rounded-md bg-gray-700 text-gray-300">Idle</div>
@@ -121,7 +134,8 @@
             imagePreviewContainer: document.getElementById('image-preview-container'),
             imagePreview: document.getElementById('image-preview'),
             removeImageBtn: document.getElementById('remove-image-btn'),
-            statusIndicator: document.getElementById('status-indicator')
+            statusIndicator: document.getElementById('status-indicator'),
+            minimalToggle: document.getElementById('minimal-toggle')
         };
 
         let attachedImageBase64 = null;
@@ -366,6 +380,10 @@
                 updateAgentStatus('Failed');
                 ui.submitButton.disabled = false;
             }
+        });
+
+        ui.minimalToggle.addEventListener('change', () => {
+            document.body.classList.toggle('minimal-mode', ui.minimalToggle.checked);
         });
 
         connectWebSocket();

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+from .file_system_tools import create_file, read_file, update_file, delete_file, list_files, get_fs_state_str
+from .git_tools import clone_repository, list_branches, checkout_branch
+from .math_tools import solve_expression, probability_distribution, calculate_descriptive_statistics
+from .physics_tools import symbolic_manipulation
+from .user_interaction_tools import log_message

--- a/tools/math_tools.py
+++ b/tools/math_tools.py
@@ -126,9 +126,14 @@ def _convert_trig_degrees(expr: str) -> str:
 
 
 def solve_expression(expression: str) -> Dict[str, Any]:
-    """Safely *eval* an arithmetic expression and return its numeric and LaTeX forms."""
+    """Safely *eval* an arithmetic expression and return its numeric and LaTeX forms.
+
+    The function also normalizes the caret (``^``) operator to Python's ``**``
+    exponentiation to provide a more user-friendly syntax.
+    """
     LOGGER.info("Evaluating expression: %s", expression)
     prepared_expr = _convert_trig_degrees(expression)
+    prepared_expr = prepared_expr.replace("^", "**")
     safe_scope = _create_safe_eval_scope()
 
     # Attempt LaTeX prettification (best‑effort)

--- a/tools/user_interaction_tools.py
+++ b/tools/user_interaction_tools.py
@@ -1,0 +1,11 @@
+"""Utility tools for user interaction and logging simple messages."""
+import logging
+
+LOGGER = logging.getLogger("UserInteractionTools")
+logging.basicConfig(level=logging.INFO)
+
+
+def log_message(message: str) -> dict:
+    """Log a message for debugging or narrative purposes."""
+    LOGGER.info(message)
+    return {"status": "success", "message": message}


### PR DESCRIPTION
## Summary
- allow natural-language tasks to be logged instead of failing
- parse arguments enclosed with double quotes
- add simple `log_message` tool for ignoring plan comments

## Testing
- `python -m py_compile tools/physics_tools.py tools/math_tools.py tools/user_interaction_tools.py agents/task_handler.py`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_685185a3b4b4832b8acbae9fd00a5ebd